### PR TITLE
fix: input split error

### DIFF
--- a/lib/utils/caller.ts
+++ b/lib/utils/caller.ts
@@ -9,7 +9,7 @@ export default class Caller {
       .slice(STACKTRACE_OFFSET);
     const callFunction = callStack?.filter((s) => !s.includes('node_modules/pino') && !s.includes('node_modules\\pino'))[1].substr(LINE_OFFSET);
     const callerObj = {
-      stack: stackTrace ? callStack : callFunction,
+      stack: stackTrace ? callStack?.join('\n') : callFunction,
     };
 
     if (typeof params[0] === 'object') {

--- a/tests/lib/utils/caller.unit.ts
+++ b/tests/lib/utils/caller.unit.ts
@@ -51,8 +51,18 @@ describe('Caller identification', () => {
     xysbdwcc(); // Execute function under test
 
     expect(params[0]).to.have.property('stack');
-    expect(params[0].stack).to.be.an('array');
-    expect(params[0].stack[0].trim().split(' ')[1]).to.eql('innerWrapper'); // Ensure the top of stack is the innerWrapper
-    expect(params[0].stack[1].trim().split(' ')[1]).to.eql('xysbdwcc'); // Ensure the next level up is the random test function name
+    expect(params[0].stack).to.be.an('string');
+    expect(
+      params[0].stack
+        .split('\n')[0]
+        .trim()
+        .split(' ')[1]
+    ).to.eql('innerWrapper'); // Ensure the top of stack is the innerWrapper
+    expect(
+      params[0].stack
+        .split('\n')[1]
+        .trim()
+        .split(' ')[1]
+    ).to.eql('xysbdwcc'); // Ensure the next level up is the random test function name
   });
 });


### PR DESCRIPTION
we did a `stack.split` here https://github.com/voiceflow/logger/blob/0bf4e5d089f460781b6003a05967488087bdd306/lib/utils/caller.ts#L8 and turned it into a string array, to call `slice` - but never turned it back into a string.