### PR TITLE
fix: fix log message type (VF-000)

### DIFF
--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -38,28 +38,28 @@ class Logger {
     }
   }
 
-  trace(...params: [any, ...any[]]): void {
-    this.logger.trace(...params);
+  trace(message: any): void {
+    this.logger.trace(message);
   }
 
-  debug(...params: [any, ...any[]]): void {
-    this.logger.debug(...params);
+  debug(message: any): void {
+    this.logger.debug(message);
   }
 
-  info(...params: [any, ...any[]]): void {
-    this.logger.info(...params);
+  info(message: any): void {
+    this.logger.info(message);
   }
 
-  warn(...params: [any, ...any[]]): void {
-    this.logger.warn(...params);
+  warn(message: any): void {
+    this.logger.warn(message);
   }
 
-  error(...params: [any, ...any[]]): void {
-    this.logger.error(...params);
+  error(message: any): void {
+    this.logger.error(message);
   }
 
-  fatal(...params: [any, ...any[]]): void {
-    this.logger.fatal(...params);
+  fatal(message: any): void {
+    this.logger.fatal(message);
   }
 
   logMiddleware(): HttpLogger {

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -38,28 +38,28 @@ class Logger {
     }
   }
 
-  trace(message: any): void {
-    this.logger.trace(message);
+  trace(message: unknown): void {
+    this.logger.trace(message as any);
   }
 
-  debug(message: any): void {
-    this.logger.debug(message);
+  debug(message: unknown): void {
+    this.logger.debug(message as any);
   }
 
-  info(message: any): void {
-    this.logger.info(message);
+  info(message: unknown): void {
+    this.logger.info(message as any);
   }
 
-  warn(message: any): void {
-    this.logger.warn(message);
+  warn(message: unknown): void {
+    this.logger.warn(message as any);
   }
 
-  error(message: any): void {
-    this.logger.error(message);
+  error(message: unknown): void {
+    this.logger.error(message as any);
   }
 
-  fatal(message: any): void {
-    this.logger.fatal(message);
+  fatal(message: unknown): void {
+    this.logger.fatal(message as any);
   }
 
   logMiddleware(): HttpLogger {


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

This changes the argument to each logging method to require 1 parameter instead of 1+.

```js
log.info('hello world'); // good
log.info('hello', 'world'); // bad, you can't do this anymore
```

This is pretty much a typings-only change. Suppling more than 1 argument works but the extras are silently ignored:

```js
log.info('hello', 'world');
// -> hello
```

### Deployment Notes

This is not a breaking change since the log behavior already ignores extra parameters.
However, this changes the type of the parameter so TypeScript users may find that updating the package will cause compilation errors.

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
