### PR TITLE
fix: only publish build folder (VF-483)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "ttypescript": "^1.5.10",
     "typescript": "^3.9.6"
   },
+  "files": [
+    "build/"
+  ],
   "homepage": "https://github.com/voiceflow/logger#readme",
   "keywords": [
     "voiceflow"
@@ -69,9 +72,9 @@
     "lint:report": "yarn lint --format json -o sonar/report.json",
     "prepare": "yarn build",
     "test": "yarn test:run",
-    "test:run": "NODE_ENV=test nyc ts-mocha --paths --opts ./config/tests/mocha.opts 'tests/**/*.{unit,it}.{ts,js}'",
     "test:dependencies": "depcheck",
     "test:integration": "NODE_ENV=test nyc --report-dir nyc_coverage_integration ts-mocha --paths --opts ./config/tests/mocha.opts 'tests/**/*.it.{ts,js}'",
+    "test:run": "NODE_ENV=test nyc ts-mocha --paths --opts ./config/tests/mocha.opts 'tests/**/*.{unit,it}.{ts,js}'",
     "test:single": "NODE_ENV=test nyc ts-mocha --paths --opts ./config/tests/mocha.opts",
     "test:unit": "NODE_ENV=test nyc --report-dir=nyc_coverage_unit ts-mocha --paths --opts ./config/tests/mocha.opts 'tests/**/*.unit.{ts,js}'"
   }


### PR DESCRIPTION
**Fixes or implements VF-483**

### Brief description. What is this change?

Only publish the `build/` folder and other required files to npm.

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| https://github.com/voiceflow/common/pull/46 | [link](https://github.com/voiceflow/common/pull/46) |
| https://github.com/voiceflow/logger/pull/23     | [link](https://github.com/voiceflow/logger/pull/23) |
| https://github.com/voiceflow/libs/pull/25     | [link](https://github.com/voiceflow/libs/pull/25) |
| https://github.com/voiceflow/general-runtime/pull/137     | [link](https://github.com/voiceflow/general-runtime/pull/137) |

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
