### PR TITLE
feat: add `.vars()` function (VF-1476)

### DIFF
--- a/lib/createMiddleware.ts
+++ b/lib/createMiddleware.ts
@@ -33,12 +33,12 @@ const createMiddleware = ({
     genReqId,
     serializers: getSerializer(verbosity),
     customLogLevel(res, err) {
-      if (res.statusCode >= 400 && res.statusCode < 500) {
-        return Level.WARN;
-      }
-
       if (res.statusCode >= 500 || err) {
         return Level.ERROR;
+      }
+
+      if (res.statusCode >= 400) {
+        return Level.WARN;
       }
 
       return Level.INFO;

--- a/lib/createMiddleware.ts
+++ b/lib/createMiddleware.ts
@@ -38,6 +38,10 @@ const createMiddleware = ({
       }
 
       if (res.statusCode >= 400) {
+        if (res.statusCode === 404) {
+          return Level.TRACE;
+        }
+
         return Level.WARN;
       }
 

--- a/lib/createMiddleware.ts
+++ b/lib/createMiddleware.ts
@@ -48,7 +48,12 @@ const createMiddleware = ({
       // @ts-ignore
       const { baseUrl, path } = res.req;
 
-      return `${res.statusCode} | ${baseUrl + path} `;
+      if (baseUrl || path) {
+        return `${res.statusCode} | ${baseUrl ?? ''}${path ?? ''} `;
+      }
+
+      // This should never happen
+      return `${res.statusCode} | (unknown path)`;
     },
   });
 

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,6 +1,7 @@
 import pino, { Logger as PinoLogger, LoggerOptions } from '@voiceflow/pino';
 import prettifier from '@voiceflow/pino-pretty';
 import { HttpLogger } from 'pino-http';
+import util from 'util';
 
 import { LogLevel } from '..';
 import { defaultConfigs, LoggerConfig } from './constants';
@@ -64,6 +65,27 @@ class Logger {
 
   logMiddleware(): HttpLogger {
     return this.middleware;
+  }
+
+  /**
+   * Format an object of variables into a string.
+   *
+   * @example
+   * ```js
+   * logger.vars({ a: 1, b: 2, c: 3 }); // '| a=1 b=2 c=3'
+   * ```
+   */
+  vars(variables: Record<string, unknown>, prefix = '| '): string {
+    return (
+      prefix +
+      Object.entries(variables)
+        .map(([key, value]) => {
+          const serializedValue = value !== null && typeof value === 'object' ? util.inspect(value) : value;
+
+          return `${key}=${serializedValue}`;
+        })
+        .join(', ')
+    );
   }
 }
 

--- a/tests/lib/logger/logger.it.ts
+++ b/tests/lib/logger/logger.it.ts
@@ -90,7 +90,7 @@ describe('Logger integration tests', () => {
     });
 
     it('Formats variables', () => {
-      expect(loggerInstance.vars({ a: 1, b: 2, c: 3 })).to.eql('a=1 b=2 c=3');
+      expect(loggerInstance.vars({ a: 1, b: 2, c: 3 }, 'pfx ')).to.eql('pfx a=1, b=2, c=3');
     });
   });
 

--- a/tests/lib/logger/logger.it.ts
+++ b/tests/lib/logger/logger.it.ts
@@ -88,6 +88,10 @@ describe('Logger integration tests', () => {
       expect(parsedLogObj).to.have.property('stack');
       expect(parsedLogObj.stack).to.be.an('string');
     });
+
+    it('Formats variables', () => {
+      expect(loggerInstance.vars({ a: 1, b: 2, c: 3 })).to.eql('a=1 b=2 c=3');
+    });
   });
 
   describe('Logger config', () => {


### PR DESCRIPTION
**Fixes or implements VF-1476**

### Brief description. What is this change?

- Add a `.vars` function for formatting objects
- Make 404 HTTP logs `TRACE` level (reduced from `WARN`)
- Stop printing `undefined` at the beginning of HTTP logs in certain environments

### Related PRs

- https://github.com/voiceflow/general-runtime/pull/165
- https://github.com/voiceflow/alexa-runtime/pull/190
- https://github.com/voiceflow/google-runtime/pull/131

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [x] appropriate tests have been written
- [ ] all the dependencies are upgraded
