### PR TITLE
fix: lower levels for health checks on middleware (RUN-31)

### DIFF
--- a/src/http.logger.ts
+++ b/src/http.logger.ts
@@ -11,12 +11,13 @@ import { createJSONConfig } from './json.logger';
 import { LogFormat } from './log-format.enum';
 import { LogLevel } from './log-level.enum';
 import { LoggerOptions } from './logger-options.interface';
-import { getColorizer, isErrorResponse, isWarnResponse } from './utils';
+import { getColorizer, isErrorResponse, isHealthRequest, isWarnResponse } from './utils';
 
 export const createHTTPConfig = ({ format, level }: LoggerOptions): Options => ({
-  customLogLevel: (_req, res) => {
+  customLogLevel: (req, res) => {
     if (isWarnResponse(res)) return LogLevel.WARN;
     if (isErrorResponse(res)) return LogLevel.ERROR;
+    if (isHealthRequest(req)) return LogLevel.TRACE;
     return LogLevel.INFO;
   },
   wrapSerializers: true,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,8 @@
-import { ServerResponse } from 'node:http';
+import { IncomingMessage, ServerResponse } from 'node:http';
 
 import { green, red, yellow } from 'colorette';
 
+export const isHealthRequest = (req: IncomingMessage) => req.url === '/health';
 export const isWarnResponse = (res: ServerResponse) => res.statusCode >= 400 && res.statusCode <= 499;
 export const isErrorResponse = (res: ServerResponse) => res.err || (res.statusCode >= 500 && res.statusCode <= 599);
 export const getColorizer = (res: ServerResponse) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import { IncomingMessage, ServerResponse } from 'node:http';
 
 import { green, red, yellow } from 'colorette';
 
-export const isHealthRequest = (req: IncomingMessage) => req.url === '/health';
+export const isHealthRequest = (req: IncomingMessage & { originalUrl?: string }) => (req.originalUrl ?? req.url) === '/health';
 export const isWarnResponse = (res: ServerResponse) => res.statusCode >= 400 && res.statusCode <= 499;
 export const isErrorResponse = (res: ServerResponse) => res.err || (res.statusCode >= 500 && res.statusCode <= 599);
 export const getColorizer = (res: ServerResponse) => {


### PR DESCRIPTION
We check our `/health` endpoint like twice every second with the readiness and liveness probes.

The hope is that we can enable `INFO` level logging across all clouds again, but also not blow up our datadog logging bill.
<img width="1719" alt="Screenshot 2024-08-16 at 11 17 53 AM" src="https://github.com/user-attachments/assets/bdca722e-12e9-4a24-b06a-c5ec1c98b104">

We honestly should have an audit log of API calls.

Our old logger did this (kind of) as well with 404 links:
https://github.com/voiceflow/logger/blob/bea10e3b961f43921b72390de21200923d1139c8/lib/createMiddleware.ts#L35