### PR TITLE
fix: http logs to debug level (RUN-34)

### DIFF
--- a/src/http.logger.ts
+++ b/src/http.logger.ts
@@ -18,7 +18,7 @@ export const createHTTPConfig = ({ format, level }: LoggerOptions): Options => (
     if (isWarnResponse(res)) return LogLevel.WARN;
     if (isErrorResponse(res)) return LogLevel.ERROR;
     if (isHealthRequest(req)) return LogLevel.TRACE;
-    return LogLevel.INFO;
+    return LogLevel.DEBUG;
   },
   wrapSerializers: true,
 


### PR DESCRIPTION
discussed with Xavi, today it would be far to noisy to have all API calls in out logs, even with the health check out.

On production we already track it with APM (it's sparse, but we can turn it to 100% if needed), so it would be redundant to also have logs.